### PR TITLE
Acts as the original Resque by JSONify arguments, so Ruby symbols become strings. Added a dependency to the json gem, but yajl is used if it's already loaded (exactly like the resque gem).

### DIFF
--- a/lib/resque_unit.rb
+++ b/lib/resque_unit.rb
@@ -1,11 +1,17 @@
 module ResqueUnit
 end
 
+begin
+  require 'yajl'
+rescue LoadError
+  require 'json'
+end
+
 require 'test/unit'
+require 'resque_unit/helpers'
 require 'resque_unit/resque'
 require 'resque_unit/errors'
 require 'resque_unit/assertions'
-
 
 Test::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 

--- a/lib/resque_unit/helpers.rb
+++ b/lib/resque_unit/helpers.rb
@@ -1,0 +1,30 @@
+module Resque
+  module Helpers
+    # Given a Ruby object, returns a string suitable for storage in a
+    # queue.
+    def encode(object)
+      if defined? Yajl
+        Yajl::Encoder.encode(object)
+      else
+        object.to_json
+      end
+    end
+
+    # Given a string, returns a Ruby object.
+    def decode(object)
+      return unless object
+
+      if defined? Yajl
+        begin
+          Yajl::Parser.parse(object, :check_utf8 => false)
+        rescue Yajl::ParseError
+        end
+      else
+        begin
+          JSON.parse(object)
+        rescue JSON::ParserError
+        end
+      end
+    end
+  end
+end

--- a/lib/resque_unit/resque.rb
+++ b/lib/resque_unit/resque.rb
@@ -1,6 +1,8 @@
 # The fake Resque class. This needs to be loaded after the real Resque
 # for the assertions in +ResqueUnit::Assertions+ to work.
 module Resque
+  include Helpers
+  extend self
 
   # Resets all the queues to the empty state. This should be called in
   # your test's +setup+ method until I can figure out a way for it to
@@ -70,7 +72,7 @@ module Resque
     queue_name = queue_for(klass)
     # Behaves like Resque, raise if no queue was specifed
     raise NoQueueError.new("Jobs must be placed onto a queue.") unless queue_name
-    queue(queue_name) << {:klass => klass, :args => args}
+    queue(queue_name) << {:klass => klass, :args => decode(encode(args))}
   end
 
   # :nodoc: 

--- a/lib/resque_unit/scheduler.rb
+++ b/lib/resque_unit/scheduler.rb
@@ -19,7 +19,7 @@ module ResqueUnit
     end
     
     def enqueue_with_timestamp(timestamp, klass, *args)
-      queue(queue_for(klass)) << {:klass => klass, :args => args, :timestamp => timestamp}
+      queue(queue_for(klass)) << {:klass => klass, :args => decode(encode(args)), :timestamp => timestamp}
     end
 
   end

--- a/resque_unit.gemspec
+++ b/resque_unit.gemspec
@@ -2,6 +2,7 @@ spec = Gem::Specification.new do |s|
   s.name = 'resque_unit'
   s.version = '0.2.6'
   s.summary = 'Test::Unit support for resque job queueing'
+  s.add_dependency "json", "~> 1.4.6"
   s.add_development_dependency "shoulda"
   s.author = "Justin Weiss"
   s.email = "justin@uberweiss.org"

--- a/test/resque_unit_test.rb
+++ b/test/resque_unit_test.rb
@@ -75,11 +75,11 @@ class ResqueUnitTest < Test::Unit::TestCase
   
   context "A task that schedules a resque job with arguments" do 
     setup do 
-      Resque.enqueue(JobWithArguments, 1, "test")
+      Resque.enqueue(JobWithArguments, 1, :test, {:symbol => :symbol})
     end
     
-    should "pass the assert_queued(job, *args) assertion if the args match" do
-      assert_queued(JobWithArguments, [1, "test"])
+    should "pass the assert_queued(job, *args) assertion if the args match and sees enqueued symbols as strings" do
+      assert_queued(JobWithArguments, [1, "test", {"symbol"=>"symbol"}])
     end
     
     should "pass the assert_queued(job) assertion with no args passed" do
@@ -98,7 +98,7 @@ class ResqueUnitTest < Test::Unit::TestCase
 
     should "fail the assert_not_queued(job) assertion if the args match" do
       assert_raise Test::Unit::AssertionFailedError do 
-        assert_not_queued(JobWithArguments, [1, "test"])
+        assert_not_queued(JobWithArguments, [1, "test", {"symbol"=>"symbol"}])
       end
     end
   end

--- a/test/sample_jobs.rb
+++ b/test/sample_jobs.rb
@@ -30,7 +30,7 @@ end
 class JobWithArguments
   @queue = :medium
 
-  def self.perform(num, text)
+  def self.perform(num, text, hash)
 
   end
 end


### PR DESCRIPTION
sorry for the merge after my commit :)

https://github.com/nfo/resque_unit/commit/da64e340ae6e7f1a40d6397b08425707880f5fbc
