### PR TITLE
Added hook support !

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ example, if you have code that queues a resque job:
       @queue = :low  
     
       def self.perform(x)
-        // do stuff
+        # do stuff
       end
     end
     
@@ -65,11 +65,48 @@ You can also access the queues directly:
       assert_equal 1, Resque.queue(:low).length
     end
 
+Finally, you can enable hooks:
+
+    Resque.enable_hooks!
+
+    class MyJobWithHooks
+      @queue = :hooked
+
+      def self.perform(x)
+        # do stuff
+      end
+
+      def self.after_enqueue_mark(*args)
+        # called when the job is enqueued
+      end
+
+      def self.before_perform_mark(*args)
+        # called just before the +perform+ method
+      end
+
+      def self.after_perform_mark(*args)
+        # called just after the +perform+ method
+      end
+
+      def self.failure_perform_mark(*args)
+        # called if the +perform+ method raised
+      end
+
+    end
+
+    def queue_job
+      Resque.enqueue(MyJobWithHooks, 1)
+    end
+
 Caveats
 =======
 
 * You should make sure that you call `Resque.reset!` in your test's
   setup method to clear all of the test queues.
+* Hooks support is optional. Just because you probably don't want to call
+  them during unit tests if they play with a DB. Call `Resque.enable_hooks!`
+  in your tests's setup method to enable hooks. To disable hooks, call
+  `Resque.disable_hooks!`.
 
 Resque-Scheduler Support
 ========================

--- a/lib/resque_unit.rb
+++ b/lib/resque_unit.rb
@@ -12,6 +12,7 @@ require 'resque_unit/helpers'
 require 'resque_unit/resque'
 require 'resque_unit/errors'
 require 'resque_unit/assertions'
+require 'resque_unit/plugin' 
 
 Test::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 

--- a/lib/resque_unit/plugin.rb
+++ b/lib/resque_unit/plugin.rb
@@ -1,0 +1,65 @@
+# A copy of the original Resque:Plugin class from the "resque" gem
+# No need to redefine this class if the resque gem was already loaded
+unless defined?(Resque::Plugin)
+
+  module Resque
+    module Plugin
+      extend self
+
+      LintError = Class.new(RuntimeError)
+
+      # Ensure that your plugin conforms to good hook naming conventions.
+      #
+      #   Resque::Plugin.lint(MyResquePlugin)
+      def lint(plugin)
+        hooks = before_hooks(plugin) + around_hooks(plugin) + after_hooks(plugin)
+
+        hooks.each do |hook|
+          if hook =~ /perform$/
+            raise LintError, "#{plugin}.#{hook} is not namespaced"
+          end
+        end
+
+        failure_hooks(plugin).each do |hook|
+          if hook =~ /failure$/
+            raise LintError, "#{plugin}.#{hook} is not namespaced"
+          end
+        end
+      end
+
+      # Given an object, returns a list `before_perform` hook names.
+      def before_hooks(job)
+        job.methods.grep(/^before_perform/).sort
+      end
+
+      # Given an object, returns a list `around_perform` hook names.
+      def around_hooks(job)
+        job.methods.grep(/^around_perform/).sort
+      end
+
+      # Given an object, returns a list `after_perform` hook names.
+      def after_hooks(job)
+        job.methods.grep(/^after_perform/).sort
+      end
+
+      # Given an object, returns a list `on_failure` hook names.
+      def failure_hooks(job)
+        job.methods.grep(/^on_failure/).sort
+      end
+
+      # Given an object, returns a list `after_enqueue` hook names.
+      def after_enqueue_hooks(job)
+        job.methods.grep(/^after_enqueue/).sort
+      end
+    end
+  end
+
+end
+
+unless defined?(Resque::Job::DontPerform)
+  module Resque
+    class Job
+      DontPerform = Class.new(StandardError)
+    end
+  end
+end

--- a/lib/resque_unit/scheduler.rb
+++ b/lib/resque_unit/scheduler.rb
@@ -19,7 +19,7 @@ module ResqueUnit
     end
     
     def enqueue_with_timestamp(timestamp, klass, *args)
-      queue(queue_for(klass)) << {:klass => klass, :args => decode(encode(args)), :timestamp => timestamp}
+      enqueue_unit(queue_for(klass), {:klass => klass, :args => decode(encode(args)), :timestamp => timestamp})
     end
 
   end

--- a/test/sample_jobs.rb
+++ b/test/sample_jobs.rb
@@ -48,3 +48,59 @@ class JobThatDoesNotSpecifyAQueue
   def self.perform
   end
 end
+
+class JobWithHooks
+  @queue = :with_hooks
+  @markers = {}
+  
+  def self.perform
+    raise 'FAIL!' if @will_fail
+  end
+  
+  def self.markers
+    @markers
+  end
+  
+  def self.clear_markers
+    @markers = {}
+  end
+  
+  def self.after_enqueue_mark(*args)
+    markers[:after_enqueue] = true
+  end
+  
+  def self.before_perform_mark(*args)
+    markers[:before] = true
+  end
+  
+  def self.around_perform_mark(*args)
+    markers[:around] = true
+    if @dont_perform
+      raise Resque::Job::DontPerform
+    else
+      yield
+    end
+  end
+  
+  def self.after_perform_mark(*args)
+    markers[:after] = true
+  end
+  
+  def self.failure_perform_mark(*args)
+    markers[:failure] = true
+  end
+  
+  def self.make_it_fail(&block)
+    @will_fail = true
+    yield
+  ensure
+    @will_fail = false
+  end
+  
+  def self.make_it_dont_perform(&block)
+    @dont_perform = true
+  ensure
+    @dont_perform = false
+  end
+  
+end


### PR DESCRIPTION
From the README:

```
Hooks support is optional. Just because you probably don't want to call
them during unit tests if they play with a DB. Call `Resque.enable_hooks!`
in your tests's setup method to enable hooks. To disable hooks, call
`Resque.disable_hooks!`.
```
