### PR TITLE
JSON gem version

### DIFF
--- a/resque_unit.gemspec
+++ b/resque_unit.gemspec
@@ -2,7 +2,7 @@ spec = Gem::Specification.new do |s|
   s.name = 'resque_unit'
   s.version = '0.3.6'
   s.summary = 'Test::Unit support for resque job queueing'
-  s.add_dependency "json", "~> 1.4.6"
+  s.add_dependency "json", ">= 1.4.6"
   s.add_development_dependency "bundler"
   s.add_development_dependency "shoulda"
   s.author = "Justin Weiss"


### PR DESCRIPTION
Hi Justin,

Is there a reason you have the json gem dependency tied to 1.4.6?  We love the gem, but have other dependencies in our application for json 1.5.1.  We tried relaxing the dependency to ">= 1.4.6" and it seems to be running fine in our environment.
- Mark
