### PR TITLE
Add support and tests for enqueue_to

### DIFF
--- a/lib/resque_unit/resque.rb
+++ b/lib/resque_unit/resque.rb
@@ -112,7 +112,11 @@ module Resque
 
   # :nodoc: 
   def enqueue(klass, *args)
-    queue_name = queue_for(klass)
+    enqueue_to( queue_for(klass), klass, *args)
+  end
+
+  # :nodoc:
+  def enqueue_to( queue_name, klass, *args )
     # Behaves like Resque, raise if no queue was specifed
     raise NoQueueError.new("Jobs must be placed onto a queue.") unless queue_name
     enqueue_unit(queue_name, {"class" => klass.name, "args" => args })
@@ -122,6 +126,7 @@ module Resque
   def queue_for(klass)
     klass.instance_variable_get(:@queue) || (klass.respond_to?(:queue) && klass.queue)
   end
+  alias :queue_from_class :queue_for
 
   # :nodoc:
   def empty_queues?

--- a/test/resque_unit_test.rb
+++ b/test/resque_unit_test.rb
@@ -17,6 +17,16 @@ class ResqueUnitTest < Test::Unit::TestCase
     end
   end
 
+  context "A task that explicitly is queued to a different queue" do
+    setup { Resque.enqueue_to(:a_non_class_determined_queue, MediumPriorityJob) }
+    should "not queue to the class-determined queue" do
+      assert_equal 0, Resque.queue(MediumPriorityJob.queue).length
+    end
+    should "queue to the explicly-stated queue" do
+      assert_equal 1, Resque.queue(:a_non_class_determined_queue).length
+    end
+  end
+
   context "A task that schedules a resque job" do
     setup do 
       @returned = Resque.enqueue(LowPriorityJob)


### PR DESCRIPTION
enqueue_to method is part of Resque's "stable api", so we should support tasks being put into explicit queues in addition to their class-determined (implicit) queues.

Also added an alias to :queue_from_class method from :queue_for since expected behavior is identical and my plugin implementation relies on this being in place.
