### PR TITLE
Fixed `Resque::Scheduler.enqueue_with_timestamp`

### DIFF
--- a/lib/resque_unit/scheduler.rb
+++ b/lib/resque_unit/scheduler.rb
@@ -19,7 +19,7 @@ module ResqueUnit
     end
     
     def enqueue_with_timestamp(timestamp, klass, *args)
-      enqueue_unit(queue_for(klass), {"class" => klass, "args" => args, "timestamp" => timestamp})
+      enqueue_unit(queue_for(klass), {"class" => klass.name, "args" => args, "timestamp" => timestamp})
     end
 
     def remove_delayed(klass, *args)


### PR DESCRIPTION
`Resque::Scheduler.enqueue_with_timestamp` must give the name of the worker class, not the class itself, like in `Resque.enqueue_to`. I don't know why there is no problem in tests, but when I try to use enqueue_in or enqueue_at in my project, this object

``` ruby
{"class"=>MyWorker, "args"=>[{"_id"=>"u123", "email"=>"lol@cats.com"}], "timestamp"=>2011-10-04 12:35:01 +0200}
```

is encoded into:

``` json
{"class":{"inheritable_attributes":{},"queue":"my_queue","args":[{"_id":"u123","email":"lol@cats.com"}],"timestamp":"2011-10-04T12:35:01+02:00"}
```

instead of:

``` json
{"class":"MyWorker","args":[{"_id":"u123","email":"lol@cats.com"}],"timestamp":"2011-10-04T12:37:42+02:00"}
```
