### PR TITLE
Correctly compare timestamps in Resque#remove_delayed_job_from_timestamp

### DIFF
--- a/lib/resque_unit/scheduler.rb
+++ b/lib/resque_unit/scheduler.rb
@@ -32,7 +32,7 @@ module ResqueUnit
     def remove_delayed_job_from_timestamp(timestamp, klass, *args)
       encoded_job_payloads = Resque.queue(queue_for(klass))
       args ||= []
-      encoded_job_payloads.delete_if { |e| e = Resque.decode(e); e["class"] == klass.to_s && Time.new(e["timestamp"]).utc == Time.new(timestamp.to_s).utc && e["args"] == args }
+      encoded_job_payloads.delete_if { |e| e = Resque.decode(e); e["class"] == klass.to_s && Time.new(e["timestamp"]).to_i == Time.new(timestamp.to_s).to_i && e["args"] == args }
     end
   end
 

--- a/test/resque_unit_scheduler_test.rb
+++ b/test/resque_unit_scheduler_test.rb
@@ -129,9 +129,25 @@ class ResqueUnitSchedulerTest < Test::Unit::TestCase
       end
     end
 
-    context "and then the job is removed with #remove_delayed_job_with_timestamp" do
+    context "and then the job is removed with #remove_delayed_job_from_timestamp" do
       setup do
         Resque.remove_delayed_job_from_timestamp(@time, MediumPriorityJob)
+      end
+
+      should "pass the assert_not_queued_at(@time, MediumPriorityJob) assertion" do
+        assert_not_queued_at(@time, MediumPriorityJob)
+      end
+
+      should "fail the assert_queued_at(@time, MediumPriorityJob) assertion" do
+        assert_raise Test::Unit::AssertionFailedError do
+          assert_queued_at(@time, MediumPriorityJob)
+        end
+      end
+    end
+
+    context "and then the job is removed with #remove_delayed_job_from_timestamp with timestamp specified in another timezone" do
+      setup do
+        Resque.remove_delayed_job_from_timestamp(@time.utc, MediumPriorityJob)
       end
 
       should "pass the assert_not_queued_at(@time, MediumPriorityJob) assertion" do
@@ -185,6 +201,22 @@ class ResqueUnitSchedulerTest < Test::Unit::TestCase
     context "and then the job is removed with #remove_delayed_job_from_timestamp" do
       setup do
         Resque.remove_delayed_job_from_timestamp(@time, JobWithArguments, 1, "test")
+      end
+
+      should "pass the assert_not_queued_at(@time, JobWithArguments, *args) assertion" do
+        assert_not_queued_at(@time, JobWithArguments, [1, "test"])
+      end
+
+      should "fail the assert_queued_at(@time, MediumPriorityJob, *args) assertion" do
+        assert_raise Test::Unit::AssertionFailedError do
+          assert_queued_at(@time, JobWithArguments, [1, "test"])
+        end
+      end
+    end
+
+    context "and then the job is removed with #remove_delayed_job_from_timestamp with timestamp in another timezone" do
+      setup do
+        Resque.remove_delayed_job_from_timestamp(@time.utc, JobWithArguments, 1, "test")
       end
 
       should "pass the assert_not_queued_at(@time, JobWithArguments, *args) assertion" do


### PR DESCRIPTION
Previously was doing a string based comparison. Worked in unit tests. However while using in a rails project realized that I was seeing issues (duh) with doing a string only comparison for vanilla time v/s rails time with time zone. 
