### PR TITLE
Fix a problem where Rake passes task arguments to TestUnit

### DIFF
--- a/lib/resque_unit.rb
+++ b/lib/resque_unit.rb
@@ -7,12 +7,12 @@ rescue LoadError
   require 'json'
 end
 
-require 'test/unit'
+require 'test/unit/testcase'
 require 'resque_unit/helpers'
 require 'resque_unit/resque'
 require 'resque_unit/errors'
 require 'resque_unit/assertions'
-require 'resque_unit/plugin' 
+require 'resque_unit/plugin'
 
 Test::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 


### PR DESCRIPTION
Unfortunately Rake 0.9 doesn't remove processed arguments (e.g. db:migrate) from ARGV and TestUnit when requirering "test/unit" tries to process ARGV and therefore tries to test arbitary rake task arguments.

Simply requirering "test/unit/testcase" works around the problem and seems to work fine.
Further information can be found here: http://stackoverflow.com/a/9571551/279024
