### PR TITLE
Moving Helpers into the ResqueUnit namespace to quiet warnings from Resque

### DIFF
--- a/lib/resque_unit/helpers.rb
+++ b/lib/resque_unit/helpers.rb
@@ -1,4 +1,4 @@
-module Resque
+module ResqueUnit
   module Helpers
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.

--- a/lib/resque_unit/resque.rb
+++ b/lib/resque_unit/resque.rb
@@ -1,7 +1,7 @@
 # The fake Resque class. This needs to be loaded after the real Resque
 # for the assertions in +ResqueUnit::Assertions+ to work.
 module Resque
-  include Helpers
+  include ResqueUnit::Helpers
   extend self
 
   # Resets all the queues to the empty state. This should be called in
@@ -215,7 +215,7 @@ module Resque
   end
 
   class Job
-    extend Helpers
+    extend ResqueUnit::Helpers
     def self.create(queue, klass_name, *args)
       Resque.enqueue_unit(queue, {"class" => constantize(klass_name).to_s, "args" => args})
     end


### PR DESCRIPTION
With the latest Resque you get deprecation warnings:

```
Resque::Helpers will be gone with no replacement in Resque 2.0.0.
Resque::Helpers will be gone with no replacement in Resque 2.0.0.
```

and this commit fixes those.
