### PR TITLE
Support renamed module and class in Minitest 5

### DIFF
--- a/lib/resque_unit.rb
+++ b/lib/resque_unit.rb
@@ -17,6 +17,10 @@ if defined?(Test::Unit)
   Test::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 end
 
-if defined?(MiniTest)
+if defined?(MiniTest::Unit::TestCase)
   MiniTest::Unit::TestCase.send(:include, ResqueUnit::Assertions)
+end
+
+if defined?(Minitest::Test)
+  Minitest::Test.send(:include, ResqueUnit::Assertions)
 end


### PR DESCRIPTION
Probably should be part of #37.

Since Minitest 5 (introduced seattlerb/minitest@9a57c520ceac76abfe6105866f8548a94eb357b6gg), automatic inclusion of `ResqueUnit::Assertions` wasn't working, and you'd get this warning when requiring `resque_unit`:

```
MiniTest::Unit::TestCase is now Minitest::Test. From /opt/ruby/lib/ruby/2.0.0/test/unit/testcase.rb:8:in `<module:Unit>'
```

This commit fixes both issues (and tests still pass).
