### PR TITLE
Prevent uninitialized constant error

### DIFF
--- a/lib/resque_unit.rb
+++ b/lib/resque_unit.rb
@@ -13,7 +13,7 @@ require 'resque_unit/errors'
 require 'resque_unit/assertions'
 require 'resque_unit/plugin'
 
-if defined?(Test::Unit)
+if defined?(Test::Unit::TestCase)
   Test::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 end
 

--- a/lib/resque_unit_scheduler.rb
+++ b/lib/resque_unit_scheduler.rb
@@ -1,7 +1,7 @@
 require 'resque_unit/scheduler'
 require 'resque_unit/scheduler_assertions'
 
-if defined?(Test::Unit)
+if defined?(Test::Unit::TestCase)
   Test::Unit::TestCase.send(:include, ResqueUnit::SchedulerAssertions)
 end
 


### PR DESCRIPTION
you can load Test::Unit without Test::Unit::TestCase