### PR TITLE
Add support for enqueue_at_with_queue

### DIFF
--- a/lib/resque_unit/scheduler.rb
+++ b/lib/resque_unit/scheduler.rb
@@ -9,7 +9,15 @@ module ResqueUnit
     # for queueing.  Until timestamp is in the past, the job will
     # sit in the schedule list.
     def enqueue_at(timestamp, klass, *args)
-      enqueue_with_timestamp(timestamp, klass, *args)
+      enqueue_with_timestamp(queue_for(klass), timestamp, klass, *args)
+    end
+
+    # Identical to +enqueue_at+, except you can also specify
+    # a queue in which the job will be placed after the
+    # timestamp has passed. It respects Resque.inline option, by
+    # creating the job right away instead of adding to the queue.
+    def enqueue_at_with_queue(queue, timestamp, klass, *args)
+      enqueue_with_timestamp(queue, timestamp, klass, *args)
     end
 
     # Identical to enqueue_at but takes number_of_seconds_from_now
@@ -18,10 +26,9 @@ module ResqueUnit
       enqueue_at(Time.now + number_of_seconds_from_now, klass, *args)
     end
 
-    def enqueue_with_timestamp(timestamp, klass, *args)
-      enqueue_unit(queue_for(klass), {"class" => klass.name, "args" => args, "timestamp" => timestamp})
+    def enqueue_with_timestamp(queue, timestamp, klass, *args)
+      enqueue_unit(queue, {"class" => klass.name, "args" => args, "timestamp" => timestamp})
     end
-
     def remove_delayed(klass, *args)
       # points to real queue
       encoded_job_payloads = Resque.queue(queue_for(klass))


### PR DESCRIPTION
Resque scheduler supports a method called `enqueue_at_with_queue` which is used by ActiveJob when enqueing jobs on a schedule. For reasons (cough, legacy), I have an app that is running both regular Resque jobs and ActiveJob jobs through rails. So, support for this method is nice to have to ensure that jobs enqueued by ActiveJob end up being testable by resque_unit.