### PR TITLE
compatibility with minitest >= 5.19.0

### DIFF
--- a/lib/resque_unit.rb
+++ b/lib/resque_unit.rb
@@ -17,8 +17,8 @@ if defined?(Test::Unit::TestCase)
   Test::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 end
 
-if defined?(MiniTest::Unit::TestCase)
-  MiniTest::Unit::TestCase.send(:include, ResqueUnit::Assertions)
+if defined?(Minitest::Unit::TestCase)
+  Minitest::Unit::TestCase.send(:include, ResqueUnit::Assertions)
 end
 
 if defined?(Minitest::Test)

--- a/lib/resque_unit/assertions.rb
+++ b/lib/resque_unit/assertions.rb
@@ -61,11 +61,11 @@ module ResqueUnit::Assertions
 
   # In Test::Unit, +assert_block+ displays only the message on a test
   # failure and +assert+ always appends a message to the end of the
-  # passed-in assertion message. In MiniTest, it's the other way
+  # passed-in assertion message. In Minitest, it's the other way
   # around. This abstracts those differences and never appends a
   # message to the one the user passed in.
   def assert_with_custom_message(value, message = nil)
-    if defined?(MiniTest::Assertions)
+    if defined?(Minitest::Assertions)
       assert value, message
     else
       assert_block message do

--- a/lib/resque_unit_scheduler.rb
+++ b/lib/resque_unit_scheduler.rb
@@ -5,8 +5,8 @@ if defined?(Test::Unit::TestCase)
   Test::Unit::TestCase.send(:include, ResqueUnit::SchedulerAssertions)
 end
 
-if defined?(MiniTest::Unit::TestCase)
-  MiniTest::Unit::TestCase.send(:include, ResqueUnit::SchedulerAssertions)
+if defined?(Minitest::Unit::TestCase)
+  Minitest::Unit::TestCase.send(:include, ResqueUnit::SchedulerAssertions)
 end
 
 if defined?(Minitest::Test)


### PR DESCRIPTION
This PR makes `resque_unit` compatible with `minitest` >= 5.19.0.

---
It fixes the following error:
```
Minitest::UnexpectedError: NoMethodError: undefined method `assert_block' for <object>
```